### PR TITLE
Fix/order of fsm states

### DIFF
--- a/agents/packages/ethlisbon/skills/price_prophet/fsm_specification.yaml
+++ b/agents/packages/ethlisbon/skills/price_prophet/fsm_specification.yaml
@@ -20,18 +20,18 @@ states:
 - TransactionRound
 - FinishedTransactionRound
 transition_func:
-    (RequestDataRound, DONE): ValidateDataRound
+    (RequestDataRound, DONE): AnnotateDataRound
     (RequestDataRound, ROUND_TIMEOUT): RequestDataRound
     (RequestDataRound, NO_MAJORITY): RequestDataRound
-    (ValidateDataRound, DONE): StoreDataRound
-    (ValidateDataRound, ROUND_TIMEOUT): RequestDataRound
-    (ValidateDataRound, NO_MAJORITY): RequestDataRound
-    (StoreDataRound, DONE): AnnotateDataRound
-    (StoreDataRound, ROUND_TIMEOUT): RequestDataRound
-    (StoreDataRound, NO_MAJORITY): RequestDataRound
-    (AnnotateDataRound, DONE): TrainModelRound
+    (AnnotateDataRound, DONE): StoreDataRound
     (AnnotateDataRound, ROUND_TIMEOUT): RequestDataRound
     (AnnotateDataRound, NO_MAJORITY): RequestDataRound
+    (StoreDataRound, DONE): ValidateDataRound
+    (StoreDataRound, ROUND_TIMEOUT): RequestDataRound
+    (StoreDataRound, NO_MAJORITY): RequestDataRound
+    (ValidateDataRound, DONE): TrainModelRound
+    (ValidateDataRound, ROUND_TIMEOUT): RequestDataRound
+    (ValidateDataRound, NO_MAJORITY): RequestDataRound
     (TrainModelRound, DONE): WeightSharingRound
     (TrainModelRound, ROUND_TIMEOUT): RequestDataRound
     (TrainModelRound, NO_MAJORITY): RequestDataRound

--- a/agents/packages/ethlisbon/skills/price_prophet/rounds.py
+++ b/agents/packages/ethlisbon/skills/price_prophet/rounds.py
@@ -182,21 +182,21 @@ class PriceProphetAbciApp(AbciApp[Event]):
     initial_states: Set[AppState] = {RequestDataRound}
     transition_function: AbciAppTransitionFunction = {
         RequestDataRound: {
-            Event.DONE: ValidateDataRound,
-            Event.ROUND_TIMEOUT: RequestDataRound,
-            Event.NO_MAJORITY: RequestDataRound
-        },
-        ValidateDataRound: {
-            Event.DONE: StoreDataRound,
-            Event.ROUND_TIMEOUT: RequestDataRound,
-            Event.NO_MAJORITY: RequestDataRound
-        },
-        StoreDataRound: {
             Event.DONE: AnnotateDataRound,
             Event.ROUND_TIMEOUT: RequestDataRound,
             Event.NO_MAJORITY: RequestDataRound
         },
         AnnotateDataRound: {
+            Event.DONE: StoreDataRound,
+            Event.ROUND_TIMEOUT: RequestDataRound,
+            Event.NO_MAJORITY: RequestDataRound
+        },
+        StoreDataRound: {
+            Event.DONE: ValidateDataRound,
+            Event.ROUND_TIMEOUT: RequestDataRound,
+            Event.NO_MAJORITY: RequestDataRound
+        },
+        ValidateDataRound: {
             Event.DONE: TrainModelRound,
             Event.ROUND_TIMEOUT: RequestDataRound,
             Event.NO_MAJORITY: RequestDataRound


### PR DESCRIPTION

changing FSM state ordering

- from 
    ```
    RequestDataRound -> ValidateDataRound -> StoreDataRound -> AnnotateDataRound -> TrainModelRound -> WeightSharingRound -> ModelValidationRound** -> PredictionRound -> TransactionRound
    ```
- to
    ```
    RequestDataRound -> AnnotateDataRound -> StoreDataRound-> ValidateDataRound -> TrainModelRound -> WeightSharingRound -> ModelValidationRound -> PredictionRound -> TransactionRound
    ```